### PR TITLE
added to command line docs

### DIFF
--- a/docs/ckbk/Commands.html
+++ b/docs/ckbk/Commands.html
@@ -221,7 +221,7 @@
 <td><p>Pressure in kilobar</p></td>
 </tr>
 <tr class="row-odd"><td><p>--Temp=y</p></td>
-<td><p>Temperature in celsus</p></td>
+<td><p>Temperature in Celsius</p></td>
 </tr>
 <tr class="row-even"><td><p>--Bulk=[y]</p></td>
 <td><p>Bulk rock composition in molar amount</p></td>
@@ -231,7 +231,7 @@
 </tr>
 </tbody>
 </table>
-<p>where <em>x</em> is an integer, <em>y</em> a float/double and <em>[]</em> an array of size <em>number of oxydes</em>.</p>
+<p>where <em>x</em> is an integer, <em>y</em> a float/double and <em>[]</em> a comma-separated list of size <em>number of oxides</em>. The list of oxides must be given in the following order: SiO2,Al2O3,CaO,MgO,FeO,K2O,Na2O,TiO2,O,Cr2O3,H2O</p>
 </section>
 <section id="single-point-calculation">
 <h1>Single point calculation<a class="headerlink" href="#single-point-calculation" title="Permalink to this headline"></a></h1>


### PR DESCRIPTION
This PR fixes a typo in `ckbk/Commands.html` and also adds the expected order of oxides.