### PR TITLE
removed hard coded solver variables

### DIFF
--- a/src/Initialize.h
+++ b/src/Initialize.h
@@ -203,13 +203,18 @@ global_variable global_variable_init(){
 	gv.max_g_phase  	= 2.5;					/** maximum delta_G of reference change during PGE 									*/
 	gv.max_fac          = 1.0;					/** maximum update factor during PGE under-relax < 0.0, over-relax > 0.0 	 		*/
 	gv.max_br			= 0.25;
-			
-	/* set of parameters to record the evolution of the norm of the mass constraint 												*/
-	gv.br_max_rlx       = 20.0;					/** maximum relaxing factor on mass constraint when #PGE iterations is too large	*/
-	gv.ur_1             = 200;					/** under relaxing factor on mass constraint if iteration is bigger that ur_1 		*/
-	gv.ur_2             = 300;					/** under relaxing factor on mass constraint if iteration is bigger that ur_2 		*/
-	gv.ur_3             = 400;					/** under relaxing factor on mass constraint if iteration is bigger that ur_2 		*/
-	gv.ur_f             = 500;					/** gives back failure when the number of iteration is bigger than ur_f 			*/
+
+	/* set of parameters to record the evolution of the norm of the mass constraint                                                 */
+	gv.it_1             = 200;                  /** first critical iteration                                                        */
+	gv.ur_1             = 4.;                   /** under relaxing factor on mass constraint if iteration is bigger than it_1       */
+	gv.it_2             = 300;                  /** second critical iteration                                                       */
+	gv.ur_2             = 10.;                  /** under relaxing factor on mass constraint if iteration is bigger than it_2       */
+	gv.it_3             = 400;                  /** third critical iteration                                                        */
+	gv.ur_3             = 20.;                  /** under relaxing factor on mass constraint if iteration is bigger than it_3       */
+	gv.it_f             = 500;                  /** gives back failure when the number of iteration is bigger than it_f             */
+	gv.it_slow          = 256;                  /** critical iteration for slow convergence                                         */
+	gv.ur_slow          = 1000.;                /** under relaxing factor on mass constraint defining overly slow convergence       */
+	gv.ur_break         = 1000000.;             /** under relaxing factor on mass constraint defining a breaking iteration          */
 
 	/* phase update options */
 	gv.re_in_n          = 1e-6;					/** fraction of phase when being reintroduce.  										*/
@@ -234,12 +239,12 @@ global_variable global_variable_init(){
 	for (int i = 0; i < 15; i++){ gv.init_prop[i] = -100.0; 							}  
 
 	/* declare chemical system */
-	gv.PGE_mass_norm  	= malloc (gv.ur_f * sizeof (double) 	); 
-	gv.PGE_total_norm  	= malloc (gv.ur_f * sizeof (double) 	); 
-	gv.gamma_norm  		= malloc (gv.ur_f * sizeof (double) 	); 
-	gv.ite_time  		= malloc (gv.ur_f * sizeof (double) 	); 
+	gv.PGE_mass_norm  	= malloc (gv.it_f * sizeof (double) 	); 
+	gv.PGE_total_norm  	= malloc (gv.it_f * sizeof (double) 	); 
+	gv.gamma_norm  		= malloc (gv.it_f * sizeof (double) 	); 
+	gv.ite_time  		= malloc (gv.it_f * sizeof (double) 	); 
 	
-	for (int i = 0; i < gv.ur_f; i++){	
+	for (int i = 0; i < gv.it_f; i++){	
 		gv.PGE_mass_norm[i] 	= 0.0;
 		gv.PGE_total_norm[i] 	= 0.0;
 		gv.gamma_norm[i] 		= 0.0;	

--- a/src/MAGEMin.h
+++ b/src/MAGEMin.h
@@ -350,12 +350,17 @@ typedef struct global_variables {
 	double   br_liq_x;
 	double   max_fac;			/** max updating factor */
 	double 	 max_br;
-	double   br_max_rlx;        /** maximum relaxing factor on mass constraint */
-	int      ur_1;				/** under-relax solution parameters in case iteration number becomes too large */
-	int      ur_2;
-	int      ur_3;
-	int      ur_f;				/** send a failed message when the number of iteration is greater than this value */
-	int 	 div;				/** send status of divergence */
+	int      it_1;              /** first critical iteration                                                      */
+	double   ur_1;              /** under relaxing factor on mass constraint if iteration is bigger than it_1     */
+	int      it_2;              /** second critical iteration                                                     */
+	double   ur_2;              /** under relaxing factor on mass constraint if iteration is bigger than it_2     */
+	int      it_3;              /** third critical iteration                                                      */
+	double   ur_3;              /** under relaxing factor on mass constraint if iteration is bigger than it_3     */
+	int      it_f;              /** send a failed message when the number of iteration is greater than this value */
+	int      it_slow;           /** critical iteration for slow convergence                                       */
+	double   ur_slow;           /** under relaxing factor on mass constraint defining overly slow convergence     */
+	double   ur_break;          /** under relaxing factor on mass constraint defining a breaking iteration        */
+	int      div;               /** send status of divergence */
 
 	/* DECLARE ARRAY FOR PGE CALCULATION */	
 	double	*dGamma;			/** array to store gamma change */

--- a/src/PGE_function.c
+++ b/src/PGE_function.c
@@ -1044,18 +1044,19 @@ global_variable PGE(	struct bulk_info 	z_b,
 
 		/* Increment global iteration value */
 		gv.global_ite += 1;
-
-		if (gv.global_ite > gv.ur_1 && gv.BR_norm < gv.br_max_tol*(gv.br_max_rlx/5.0)){		if (gv.verbose != 2){printf(" >200 iterations, under-relax mass constraint norm (*2.0)\n\n");}		break;	}
-		if (gv.global_ite > gv.ur_2 && gv.BR_norm < gv.br_max_tol*(gv.br_max_rlx/2.0)){		if (gv.verbose != 2){printf(" >300 iterations, under-relax mass constraint norm (*5.0)\n\n");}		break;	}
-		if (gv.global_ite > gv.ur_3 && gv.BR_norm < gv.br_max_tol*gv.br_max_rlx){			if (gv.verbose != 2){printf(" >400 iterations, under-relax mass constraint norm (*10.0)\n\n");}		break;	}
-		if (gv.global_ite > gv.ur_f){														if (gv.verbose != 2){printf(" >500 iterations, did not converge  !!!\n\n");}						break;	}
+		if (gv.global_ite > gv.it_1 && gv.BR_norm < gv.br_max_tol*gv.ur_1){		if (gv.verbose != 2){printf(" >%d iterations, under-relax mass constraint norm (*%.1f)\n\n", gv.it_1, gv.ur_1);}		break;	}
+		if (gv.global_ite > gv.it_2 && gv.BR_norm < gv.br_max_tol*gv.ur_2){		if (gv.verbose != 2){printf(" >%d iterations, under-relax mass constraint norm (*%.1f)\n\n", gv.it_2, gv.ur_2);}		break;	}
+		if (gv.global_ite > gv.it_3 && gv.BR_norm < gv.br_max_tol*gv.ur_3){		if (gv.verbose != 2){printf(" >%d iterations, under-relax mass constraint norm (*%.1f)\n\n", gv.it_3, gv.ur_3);}		break;	}
+		if (gv.global_ite > gv.it_f){											if (gv.verbose != 2){printf(" >%d iterations, did not converge  !!!\n\n", gv.it_f);}						break;	}
 
 		/* check evolution of mass constraint residual */
-		gv.PGE_mass_norm[gv.global_ite]  = gv.BR_norm;	/** sav norm for the current global iteration */
+		gv.PGE_mass_norm[gv.global_ite]  = gv.BR_norm;	/** save norm for the current global iteration */
 		gv.PGE_total_norm[gv.global_ite] = gv.fc_norm_t1;
 
-		/* capture points that fail to converge */
-		if ((gv.global_ite > 256 && gv.BR_norm > 0.01) || gv.BR_norm > 10.0){	
+		// capture points that fail to converge sufficiently quickly
+		// or have a very large norm after any iteration
+		if ((gv.global_ite > gv.it_slow && gv.BR_norm > gv.br_max_tol*gv.ur_slow) ||
+			 gv.BR_norm > gv.br_max_tol*gv.ur_break){
 			gv.div = 1;	
 		}
 		for (int i = 0; i < gv.len_cp; i++){

--- a/src/dump_function.c
+++ b/src/dump_function.c
@@ -287,11 +287,19 @@ void dump_results_function(		global_variable 	gv,
 		if (numprocs==1){	sprintf(out_lm,	"%s_pseudosection_output.txt"		,gv.outpath); 		}
 		else 			{	sprintf(out_lm,	"%s_pseudosection_output.%i.txt"	,gv.outpath, rank); }
 
-		int result = 0;							//result, 0 success, 1 under-relaxed, 2 more under-relaxed, 3 failed
-		if (gv.global_ite > gv.ur_1){ result = 1;	}
-		if (gv.global_ite > gv.ur_2){ result = 2;	}
-		if (gv.global_ite > gv.ur_3){ result = 2;	}
-		if (gv.global_ite > gv.ur_f){ result = 3;	}
+		/**
+		 * Solver result (see documentation in PGE_function.c for more details)
+		 * 0: success
+		 * 1: under-relaxed
+		 * 2: more under-relaxed
+		 * 3: reached max iterations (failed)
+		 * 4: terminated due to slow convergence or a very large residual (failed)
+		**/
+		int result = 0;
+		if (gv.global_ite > gv.it_1){ result = 1;	}
+		if (gv.global_ite > gv.it_2){ result = 2;	}
+		if (gv.global_ite > gv.it_3){ result = 2;	}
+		if (gv.global_ite > gv.it_f){ result = 3;	}
 		if (gv.div == 1){ 			  result = 4;	}
 		
 		/* get number of repeated phases for the solvi */

--- a/src/io_function.c
+++ b/src/io_function.c
@@ -225,11 +225,19 @@ void AddResults_output_struct(		global_variable 	gv,
 {
 	int i,j,num;
 
-	int status = 0;							//status, 0 success, 1 under-relaxed, 2 more under-relaxed, 3 failed
-	if (gv.global_ite > gv.ur_1){ status = 1;	}
-	if (gv.global_ite > gv.ur_2){ status = 2;	}
-	if (gv.global_ite > gv.ur_3){ status = 2;	}
-	if (gv.global_ite > gv.ur_f){ status = 3;	}
+	/**
+	 * Solver status (see documentation in PGE_function.c for more details)
+	 * 0: success
+	 * 1: under-relaxed
+	 * 2: more under-relaxed
+	 * 3: reached max iterations (failed)
+	 * 4: terminated due to slow convergence or a very large residual (failed)
+	**/
+	int status = 0;
+	if (gv.global_ite > gv.it_1){ status = 1;	}
+	if (gv.global_ite > gv.it_2){ status = 2;	}
+	if (gv.global_ite > gv.it_3){ status = 2;	}
+	if (gv.global_ite > gv.it_f){ status = 3;	}
 	if (gv.div == 1){ 			  status = 4;	}
 
 	printf("\n ********* Outputting data: P=%f \n",z_b.P);

--- a/src/ss_min_function.c
+++ b/src/ss_min_function.c
@@ -327,7 +327,7 @@ global_variable reset_global_variables(		global_variable 	gv,
 	gv.n_pp_phase         = 0;					/** reset the number of pp phases to start with */
 	gv.alpha          	  = gv.max_fac;
 
-    for (i = 0; i < gv.ur_f; i++){	
+    for (i = 0; i < gv.it_f; i++){
         gv.PGE_mass_norm[i] = 0.0;
     }
 


### PR DESCRIPTION
This PR:
- moves some of the hard-coded solver variables into the Initialize header
- renames `ur_` variables as `it_` variables
- adds a little more information about the solver statuses into the docstrings

This shouldn't change any behaviour, except that the print statements in PGE_function.c should now print the correct relaxation factors (they were written 2, 5 and 10, when the code actually used 20/5=4, 20/2=10 and 20).

(I don't mind if you don't want to accept these changes; I was just hunting down why some solves failed and made these tweaks at the same time)