### PR TITLE
Indent script

### DIFF
--- a/utilities/indent
+++ b/utilities/indent
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# collect all header and source files and process them in batches of 50 files
+# with up to 10 in parallel
+
+# remove execute permission on source files:
+find src \( -name '*.c' -o -name '*.h' \) -print | xargs -n 50 -P 10 chmod -x
+find julia \( -name '*.jl' \) -print | xargs -n 50 -P 10 chmod -x
+find matlab \( -name '*.m' \) -print | xargs -n 50 -P 10 chmod -x
+
+# convert tabs to four spaces:
+tab_to_space()
+{
+    f=$1
+    # awkward tab replacement because of OSX sed, do not change unless you test it on OSX
+    TAB=$'\t'
+    sed -e "s/$TAB/    /g" $f >$f.tmp
+    diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
+    rm -f $f.tmp
+}
+export -f tab_to_space
+find src \( -name '*.c' -o -name '*.h' \) -print | xargs -n 1 -P 10 -I {} bash -c 'tab_to_space "$@"' _ {}
+find julia \( -name '*.jl' \) -print | xargs -n 1 -P 10 -I {} bash -c 'tab_to_space "$@"' _ {}
+find matlab \( -name '*.m' \) -print | xargs -n 1 -P 10 -I {} bash -c 'tab_to_space "$@"' _ {}
+
+# Remove trailing whitespace from files
+remove_trailing_whitespace()
+{
+    f=$1
+    # awkward tab replacement because of OSX sed, do not change unless you test it on OSX
+    TAB=$'\t'
+    sed -e "s/[ $TAB]*$//"  $f >$f.tmp
+    diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
+    rm -f $f.tmp
+}
+export -f remove_trailing_whitespace
+find src \( -name '*.c' -o -name '*.h' \) -print | xargs -n 1 -P 10 -I {} bash -c 'remove_trailing_whitespace "$@"' _ {}
+find julia \( -name '*.jl' \) -print | xargs -n 1 -P 10 -I {} bash -c 'remove_trailing_whitespace "$@"' _ {}
+find matlab \( -name '*.m' \) -print | xargs -n 1 -P 10 -I {} bash -c 'remove_trailing_whitespace "$@"' _ {}
+
+# Ensure only a single newline at end of files
+ensure_single_trailing_newline()
+{
+  f=$1
+
+  # Remove newlines at end of file
+  # Check that the current line only contains newlines
+  # If it doesn't match, print it
+  # If it does match and we're not at the end of the file,
+  # append the next line to the current line and repeat the check
+  # If it does match and we're at the end of the file,
+  # remove the line.
+  sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' $f >$f.tmpi
+
+  # Then add a newline to the end of the file
+  # '$' denotes the end of file
+  # 'a\' appends the following text (which in this case is nothing)
+  # on a new line
+  sed -e '$a\' $f.tmpi >$f.tmp
+
+  diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
+  rm -f $f.tmp $f.tmpi
+}
+export -f ensure_single_trailing_newline
+find src \( -name '*.c' -o -name '*.h' \) -print | xargs -n 1 -P 10 -I {} bash -c 'ensure_single_trailing_newline "$@"' _ {}
+find julia \( -name '*.jl' \) -print | xargs -n 1 -P 10 -I {} bash -c 'ensure_single_trailing_newline "$@"' _ {}
+find matlab \( -name '*.m' \) -print | xargs -n 1 -P 10 -I {} bash -c 'ensure_single_trailing_newline "$@"' _ {}
+
+exit 0


### PR DESCRIPTION
This PR adds a utilities script that does some basic code formatting. It:
- removes execute permissions from source files
- converts tabs to four spaces (this seems to be the norm for MAGEMin)
- removes trailing whitespace
- ensures single trailing newlines

Currently, it's set up to touch .jl files in the julia directory, .m files in the matlab directory, and .c and .h files in the src directory.
The script should be run from the root directory via `./utilities/indent`. 
I haven't done this in this PR, because it will touch a lot of files and I think it's better for a maintainer to choose which functions they want to use on each directory and run the script for the first time. After that, developers can use the script to adjust their files before each PR).

We use similar scripts to maintain the ASPECT and BurnMan codes, and it saves a massive amount of time.
