### PR TITLE
normalise bulk_M and bulk_S

### DIFF
--- a/src/dump_function.c
+++ b/src/dump_function.c
@@ -372,18 +372,42 @@ void fill_output_struct(		global_variable 	 gv,
 	}
 
 	sum = 0.0;
+	sum_mol = 0.0;
 	for (j = 0; j < gv.len_ox; j++){
 		sp[0].bulk_S_wt[j]	    = sp[0].bulk_S[j]*z_b.masspo[j];
 		sum 				   += sp[0].bulk_S_wt[j];
+		sum_mol 			   += sp[0].bulk_S[j];
 	}
 
 	for (j = 0; j < gv.len_ox; j++){
 		sp[0].bulk_S_wt[j]	   /= sum;
+		sp[0].bulk_S[j] 	   /= sum_mol;
 	}
 
 	atp2wt = sum/sum_Molar_mass_bulk;
 	sp[0].frac_S_wt 		    = sp[0].frac_S*atp2wt;
 
+	/* normalize bulk_M */
+
+	for (j = 0; j < gv.len_ox; j++){
+		sp[0].bulk_M[j]	   		/= sp[0].frac_M;
+	}
+
+	sum 	= 0.0;
+	sum_mol = 0.0;
+	for (j = 0; j < gv.len_ox; j++){
+		sp[0].bulk_M_wt[j]	    = sp[0].bulk_M[j]*z_b.masspo[j];
+		sum 				   += sp[0].bulk_M_wt[j];
+		sum_mol 			   += sp[0].bulk_M[j];
+	}
+
+	for (j = 0; j < gv.len_ox; j++){
+		sp[0].bulk_M_wt[j]	   /= sum;
+		sp[0].bulk_M[j] 	   /= sum_mol;
+	}
+
+	atp2wt = sum/sum_Molar_mass_bulk;
+	sp[0].frac_M_wt 		    = sp[0].frac_M*atp2wt;
 
 	/* normalize rho_F and bulk_F */
 	sp[0].rho_F  				/= sp[0].frac_F;

--- a/src/dump_function.c
+++ b/src/dump_function.c
@@ -388,7 +388,6 @@ void fill_output_struct(		global_variable 	 gv,
 	sp[0].frac_S_wt 		    = sp[0].frac_S*atp2wt;
 
 	/* normalize bulk_M */
-
 	for (j = 0; j < gv.len_ox; j++){
 		sp[0].bulk_M[j]	   		/= sp[0].frac_M;
 	}


### PR DESCRIPTION
Currently, bulk_S and bulk_M don't sum up to 1:

```
using MAGEMin_C

data = Initialize_MAGEMin("mp", verbose=false);
Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "K2O"; "Na2O"; "TiO2"; "MnO"; "H2O"; "O"]
bulk_in_forshaw = [70.48; 25.43/2; 0.77; 3.95; 6.3; 5.54/2; 2.94/2; 0.75/2; 0.07; 100/2; 0.1]

P = 8.0
T = 700.0
sys_in = "mol"
out     = single_point_minimization(P, T, data, X=bulk_in_forshaw, Xoxides=Xoxides)

@show sum(out.bulk_M)
@show sum(out.bulk_S)
```

gives

```
sum(out.bulk_M) = 0.9918482182557748
sum(out.bulk_S) = 0.9905868382694237
```

This PR corrects this:

```
sum(out.bulk_M) = 1.0
sum(out.bulk_S) = 1.0
```
