### PR TITLE
correct printing output

### DIFF
--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -930,6 +930,7 @@ function show(io::IO, g::gmin_struct)
     for i=1:length(g.ph)
         println(io, "   $(lpad(g.ph[i],14," "))   $( round(g.ph_frac_wt[i], digits=5)) ")
     end
+    println(io, "     Stable phase | Fraction (vol fraction) ")
     for i=1:length(g.ph)
         println(io, "   $(lpad(g.ph[i],14," "))   $( round(g.ph_frac_vol[i], digits=5)) ")
     end


### PR DESCRIPTION
Correct small typo on new printing 
before on printing:
```
Pressure          : 8.0      [kbar]
Temperature       : 700.0    [Celsius]
     Stable phase | Fraction (mol fraction) 
              fsp   0.0227 
               bi   0.12761 
                g   0.04639 
               mu   0.08118 
              liq   0.23038 
             ilmm   0.00023 
                q   0.19674 
               ky   0.07259 
              H2O   0.22219 
     Stable phase | Fraction (wt fraction) 
              fsp   0.02902 
               bi   0.16809 
                g   0.06847 
               mu   0.09492 
              liq   0.223 
             ilmm   0.00042 
                q   0.24306 
               ky   0.0907 
              H2O   0.08231 
              fsp   0.0249 
               bi   0.12621 
                g   0.0383 
               mu   0.07691 
              liq   0.24582 
             ilmm   0.00021 
                q   0.2132 
               ky   0.0571 
              H2O   0.21736 
Gibbs free energy : -793.315254  (47 iterations; 53.69 ms)
Oxygen fugacity          : -16.113241469548054
Delta QFM                : 0.10156693977510146
```
And now:
```
Pressure          : 8.0      [kbar]
Temperature       : 700.0    [Celsius]
     Stable phase | Fraction (mol fraction) 
              fsp   0.0227 
               bi   0.12761 
                g   0.04639 
               mu   0.08118 
              liq   0.23038 
             ilmm   0.00023 
                q   0.19674 
               ky   0.07259 
              H2O   0.22219 
     Stable phase | Fraction (wt fraction) 
              fsp   0.02902 
               bi   0.16809 
                g   0.06847 
               mu   0.09492 
              liq   0.223 
             ilmm   0.00042 
                q   0.24306 
               ky   0.0907 
              H2O   0.08231
     Stable phase | Fraction (vol fraction)  
              fsp   0.0249 
               bi   0.12621 
                g   0.0383 
               mu   0.07691 
              liq   0.24582 
             ilmm   0.00021 
                q   0.2132 
               ky   0.0571 
              H2O   0.21736 
Gibbs free energy : -793.315254  (47 iterations; 53.69 ms)
Oxygen fugacity          : -16.113241469548054
Delta QFM                : 0.10156693977510146
```