### PR TITLE
MAGEMin v1.8.5

### DIFF
--- a/gen/magemin_library.jl
+++ b/gen/magemin_library.jl
@@ -613,6 +613,7 @@ mutable struct global_variables
     mpSp::Cint
     mpIlm::Cint
     ig_ed::Cint
+    fixed_bulk::Cint
     fluidSpec::Cint
     n_fs_db::Cint
     test::Cint

--- a/gen/magemin_library.jl
+++ b/gen/magemin_library.jl
@@ -57,6 +57,10 @@ function Access_FS_DB(id)
     ccall((:Access_FS_DB, libMAGEMin), FS_db, (Cint,), id)
 end
 
+function get_arr_em_db_tc(EM_dataset)
+    ccall((:get_arr_em_db_tc, libMAGEMin), Ptr{EM_db}, (Cint,), EM_dataset)
+end
+
 struct PP_refs
     Name::NTuple{20, Cchar}
     Comp::NTuple{15, Cdouble}

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -1566,7 +1566,7 @@ Mode  :  0.18022  0.00161  0.00174  0.04239  0.33178  0.15155  0.01325  0.24445 
 function pwm_init(P::Float64,T::Float64, gv, z_b, DB, splx_data)
 
     # input_data      =   LibMAGEMin.io_data();                           # zero (not used actually)
-
+    
     z_b.T           =   T + 273.15    # in K
     z_b.P           =   P
 

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -1563,10 +1563,10 @@ Mode  :  0.18022  0.00161  0.00174  0.04239  0.33178  0.15155  0.01325  0.24445 
 ```
 
 """
-function pwm_init(P::Float64,T::Float64, gv, z_b, DB, splx_data)
+function pwm_init(P::Float64,T::Float64, gv, z_b, DB, splx_data; G0 = true)
 
     # input_data      =   LibMAGEMin.io_data();                           # zero (not used actually)
-    
+
     z_b.T           =   T + 273.15    # in K
     z_b.P           =   P
 
@@ -1583,12 +1583,14 @@ function pwm_init(P::Float64,T::Float64, gv, z_b, DB, splx_data)
     LibMAGEMin.reset_SS(gv,z_b, DB.SS_ref_db)
     LibMAGEMin.reset_sp(gv, DB.sp)
 
-    gv      = LibMAGEMin.ComputeG0_point(gv.EM_database, z_b, gv, DB.PP_ref_db,DB.SS_ref_db);
+    if G0 == true
+        gv      = LibMAGEMin.ComputeG0_point(gv.EM_database, z_b, gv, DB.PP_ref_db,DB.SS_ref_db);
+    end
 
     return (gv, z_b, DB, splx_data)
 end
 
-pwm_init(P::Number,T::Number, gv, z_b, DB, splx_data) = pwm_init(Float64(P),Float64(T), gv, z_b, DB, splx_data)
+pwm_init(P::Number,T::Number, gv, z_b, DB, splx_data) = pwm_init(Float64(P),Float64(T), gv, z_b, DB, splx_data; G0 = true)
 
 
 function pwm_run(gv, z_b, DB, splx_data; name_solvus = false)

--- a/src/MAGEMin.h
+++ b/src/MAGEMin.h
@@ -84,6 +84,7 @@ typedef struct global_variables {
 	int      mpSp;
 	int      mpIlm;
 	int      ig_ed;			/** igneous endmember database? */
+	int      fixed_bulk;
 	
 	/* FLUID SPECIATION OPTIONS */
 	int      fluidSpec;			/** activate fluid speciation along with phase equilibrium modelling? */

--- a/src/TC_database/TC_endmembers.c
+++ b/src/TC_database/TC_endmembers.c
@@ -11696,6 +11696,29 @@ FS_db arr_fs_db_Miron2017[44] = {
 	}
 };
 
+EM_db* get_arr_em_db_tc( int EM_dataset) {
+	if (EM_dataset == 62){	
+	 	return arr_em_db_tc_ds62;
+	}
+	else if (EM_dataset == 633){		
+		return arr_em_db_tc_ds633; 
+	}
+	else if (EM_dataset == 634){		
+		return arr_em_db_tc_ds634;
+	}
+	else if (EM_dataset == 635){		
+		return arr_em_db_tc_ds635;
+	}
+	else if (EM_dataset == 636){		
+		return arr_em_db_tc_ds636;
+	}
+    else{
+        printf(" Wrong endmember dataset, values should be 62, 633, 634, 635 or 636\n");
+        printf(" -> using default ds-633 to avoid ugly crash\n"); 
+        return arr_em_db_tc_ds633;   
+    }
+}
+
 /* Select required thermodynamic database */
 EM_db Access_EM_DB(int id, int EM_dataset) {
 	EM_db Entry_EM;

--- a/src/TC_database/TC_endmembers.h
+++ b/src/TC_database/TC_endmembers.h
@@ -11,6 +11,7 @@
 #ifndef __ENDMEMBER_DATABASE_TC_H_
 #define __ENDMEMBER_DATABASE_TC_H_
 
+
     /** store endmember database **/
     typedef struct EM_db_ {
         char   Name[20];			/** pure species name 														*/
@@ -33,5 +34,11 @@
     EM_db Access_EM_DB(int id, int EM_dataset);
 
     FS_db Access_FS_DB(int id);
-
+    
+    // extern EM_db arr_em_db_tc_ds62[257];
+    // extern EM_db arr_em_db_tc_ds633[289];
+    // extern EM_db arr_em_db_tc_ds634[291];
+    // extern EM_db arr_em_db_tc_ds635[291];
+    // extern EM_db arr_em_db_tc_ds636[291];
+    EM_db* get_arr_em_db_tc( int EM_dataset);
 #endif

--- a/src/initialize.c
+++ b/src/initialize.c
@@ -122,7 +122,7 @@ global_variable global_variable_alloc( bulk_info  *z_b ){
 	}
 
 	strcpy(gv.outpath,"./output/");				/** define the outpath to save logs and final results file	 						*/
-	strcpy(gv.version,"1.8.5 [20/09/2025]");	/** MAGEMin version 																*/
+	strcpy(gv.version,"1.8.5 [15/09/2025]");	/** MAGEMin version 																*/
 
 	/* generate parameters        		*/
 	strcpy(gv.buffer,"none");
@@ -133,6 +133,7 @@ global_variable global_variable_alloc( bulk_info  *z_b ){
 	gv.buffer_n 		= 0.0;					/** factor for QFM buffer 															*/
 	gv.limitCaOpx       = 0;					/** limit Ca-bearing  orthopyroxene (add-hoc correction) 							*/
 	gv.CaOpxLim         = 1.0;					/** limit Ca-bearing  orthopyroxene (add-hoc correction) 							*/
+	gv.fixed_bulk	    = 0;                   /** by default we don't activate the initial guess for fixed bulk 					*/
 
 	/* Phase selection 					*/
 	gv.mbCpx 			= 0;					/** 0: omphacite LT, 1: augite HT													*/
@@ -674,6 +675,7 @@ global_variable reset_gv(					global_variable 	 gv,
 		}
 	}
 	gv.leveling_mode	  = 0;
+	gv.fixed_bulk		  = 0;
 	gv.tot_time 	  	  = 0.0;
 	gv.tot_min_time 	  = 0.0;
 	gv.melt_fraction	  = 0.;

--- a/src/initialize.c
+++ b/src/initialize.c
@@ -122,7 +122,7 @@ global_variable global_variable_alloc( bulk_info  *z_b ){
 	}
 
 	strcpy(gv.outpath,"./output/");				/** define the outpath to save logs and final results file	 						*/
-	strcpy(gv.version,"1.8.4 [13/09/2025]");	/** MAGEMin version 																*/
+	strcpy(gv.version,"1.8.5 [20/09/2025]");	/** MAGEMin version 																*/
 
 	/* generate parameters        		*/
 	strcpy(gv.buffer,"none");

--- a/src/simplex_levelling.c
+++ b/src/simplex_levelling.c
@@ -1169,19 +1169,21 @@ void run_initial_guess_levelling(		bulk_info 	 		 z_b,
 
 	int i, k, iss;
 
-	// fill_simplex_arrays_A(					z_b,
-	// 									    splx_data,
-	// 										gv,
-	// 										PP_ref_db,
-	// 										SS_ref_db		);
-	
-	initialize_initial_guess(			z_b,
-										splx_data,
-										gv,
-										PP_ref_db,
-										SS_ref_db				);		
-										
-										
+	if (gv.fixed_bulk == 0){
+		fill_simplex_arrays_A(					z_b,
+												splx_data,
+												gv,
+												PP_ref_db,
+												SS_ref_db		);
+	}
+	else{
+		initialize_initial_guess(			z_b,
+											splx_data,
+											gv,
+											PP_ref_db,
+											SS_ref_db				);		
+	}
+								
 	update_local_gamma(					d->A1,
 										d->g0_A,
 										d->gamma_ps,

--- a/src/ss_min_function.c
+++ b/src/ss_min_function.c
@@ -474,7 +474,7 @@ void ss_min_LP(			global_variable 	 gv,
 		if (cp[i].ss_flags[0] == 1){
 			ph_id = cp[i].id;
 
-			if ( strcmp( gv.SS_list[ph_id], "liq") == 0 && gv.n_min[ph_id] > 3){
+			if ( strcmp( gv.SS_list[ph_id], "liq") == 0 && gv.n_min[ph_id] > 2){
 				act = 0;
 			}
 			else{

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -535,6 +535,49 @@ end
 end
 
 
+@testset "Text initial guess" begin
+
+    MAGEMin_data    = Initialize_MAGEMin("ig", verbose=false, solver=0);
+
+    Xoxides         = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "K2O"; "Na2O"; "TiO2"; "O"; "Cr2O3"; "H2O"];
+    X1              = [70.999,  12.805, 0.771,  3.978,  6.342,  2.7895, 1.481,  0.758,  0.72933,    0.1,    3.0];
+    X2              = [70.999,  12.805, 0.771,  3.978,  6.342,  2.7895, 1.481,  0.758,  0.72933,    0.1,    9.0];
+    X3              = [70.999,  12.805, 0.771,  3.978,  6.342,  2.7895, 1.481,  0.758,  0.72933,    0.1,    15.0];
+    X4              = [70.999,  12.805, 0.771,  3.978,  6.342,  2.7895, 1.481,  0.758,  0.72933,    0.1,    21.0];
+    sys_in          = "mol";
+
+    P, T            = 19.0, 1350.0;
+
+    Pvec,Tvec       = [19.0,19.0,19.5,19.5], [1325.0,1350.0,1325.0,1350.0]
+
+    Xvec            = [X1,X2,X3,X4] # here the composition can also be slightly varied. how much I am not quite sure yet
+
+    Out_XY          = Vector{MAGEMin_C.gmin_struct}(undef,length(Pvec))
+    Out_XY_ig       = Vector{MAGEMin_C.gmin_struct}(undef,length(Pvec))
+    Out_XY          = multi_point_minimization( Pvec, Tvec, MAGEMin_data;
+                                                X=Xvec, Xoxides=Xoxides, sys_in=sys_in, 
+                                                name_solvus=true); 
+
+                            
+    tmp             = [Out_XY[i].mSS_vec for i=1:length(Pvec)]
+    Gig             = vcat(tmp...)                  
+
+    Out_ig          = single_point_minimization(    19.25, 1337.5,
+                                                    MAGEMin_data;
+                                                    X           = sum(Xvec)./4.0,
+                                                    Xoxides     = Xoxides,
+                                                    sys_in      = sys_in, 
+                                                    name_solvus = true,
+                                                    iguess      = true,
+                                                    G           = [Gig]);
+                                            
+    Finalize_MAGEMin(MAGEMin_data)
+
+    @test sort(Out_ig.ph) == sort(["liq", "spl"])
+end
+
+
+
 # Stores data of tests
 mutable struct outP{ _T  } 
     P           ::  _T

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -75,7 +75,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [78.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"
-    out_hT  = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in, light=true)
+    out_hT  = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in, light=true);
 
     @test sort(out_hT.ph_id_db) == sort([1, 1, 3, 4, 6, 10, 12])
     @test out_hT.ph_type == [1, 1, 1, 1, 1, 0, 0]
@@ -92,7 +92,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"
-    out_hT  = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out_hT  = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     Δρ_hT   = abs( out_hT.rho - ((out_hT.frac_M_wt * out_hT.rho_M + out_hT.frac_S_wt * out_hT.rho_S )) )
     @test Δρ_hT < 1e-10
     Finalize_MAGEMin(data)
@@ -103,7 +103,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"
-    out_lT  = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out_lT  = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     Δρ_lT = abs( out_lT.rho - ((out_lT.frac_M_wt * out_lT.rho_M + out_lT.frac_S_wt * out_lT.rho_S )) )
     @test Δρ_lT < 1e-10
     Finalize_MAGEMin(data)
@@ -114,7 +114,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"
-    out_BhT = single_point_minimization(P, T, data, X=X, B=0.0, Xoxides=Xoxides, sys_in=sys_in)
+    out_BhT = single_point_minimization(P, T, data, X=X, B=0.0, Xoxides=Xoxides, sys_in=sys_in);
     Δρ_BhT  = abs( out_BhT.rho - ((out_BhT.frac_M_wt * out_BhT.rho_M + out_BhT.frac_S_wt * out_BhT.rho_S )) )
     @test Δρ_BhT < 1e-10
     Finalize_MAGEMin(data)
@@ -125,7 +125,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"
-    out_BlT = single_point_minimization(P, T, data, X=X, B=0.0, Xoxides=Xoxides, sys_in=sys_in)
+    out_BlT = single_point_minimization(P, T, data, X=X, B=0.0, Xoxides=Xoxides, sys_in=sys_in);
     Δρ_BlT  = abs( out_BlT.rho - ((out_BlT.frac_M_wt * out_BlT.rho_M + out_BlT.frac_S_wt * out_BlT.rho_S )) )
     @test Δρ_BlT < 1e-10
     Finalize_MAGEMin(data)
@@ -166,7 +166,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     @test sort(out.ph) == sort(["cpx", "liq", "opx", "qfm"])
 
     Finalize_MAGEMin(data)
@@ -176,7 +176,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     @test sort(out.ph) == sort(["opx", "liq", "cpx", "iw"])
 
     Finalize_MAGEMin(data)
@@ -197,7 +197,7 @@ end
     Xoxides = ["SiO2","Al2O3","CaO","MgO","FeO","K2O","Na2O","TiO2","O","MnO","H2O"]
     X       = [70.999,12.805,0.771,3.978,6.342,2.7895,1.481,0.758,0.72933,0.075,30.0]
     sys_in  = "mol"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     @test sum(out.frac_M_vol + out.frac_F_vol + out.frac_S_vol) ≈ 1.0
     Finalize_MAGEMin(data)
 
@@ -206,7 +206,7 @@ end
     Xoxides = ["SiO2","Al2O3","CaO","MgO","FeO","K2O","Na2O","TiO2","O","MnO","H2O"]
     X       = [70.999,12.805,0.771,3.978,6.342,2.7895,1.481,0.758,0.72933,0.075,30.0]
     sys_in  = "mol"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     Finalize_MAGEMin(data)
     @test sum(out.frac_M_vol + out.frac_F_vol + out.frac_S_vol) ≈ 1.0
 end
@@ -218,7 +218,7 @@ end
     Xoxides = ["SiO2";  "TiO2";  "Al2O3";  "FeO";   "MnO";   "MgO";   "CaO";   "Na2O";  "K2O"; "H2O"; "O"];
     X       = [58.509,  1.022,   14.858, 4.371, 0.141, 4.561, 5.912, 3.296, 2.399, 10.0, 0.0];
     sys_in  = "wt"
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
 
     # use compo from experiment from Boehnke et al., 2013
     compo1 = [54.2, 0.5, 16.9, 4.1, 0.0, 2, 7.6, 2.3, 0.8, 0, 0]
@@ -233,7 +233,7 @@ end
 
     # test crisp and berry 2022, use compo from their example in the calculator from their paper
     P,T     = 20.0, 750.0
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
 
     bulk_melt = [61.26, 0, 13.12, 1.33, 0, 0.45, 2.51, 2.26, 2.15, 15.00, 0]
     # convert bulk_melt from wt to mol of oxides
@@ -329,7 +329,7 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X       = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     sys_in  = "wt"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
 
     @test abs(out.G_system + 916.8283889543869)/abs(916.8283889543869) < 2e-4
 
@@ -341,7 +341,7 @@ end
     X2      = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     X       = [X1,X2]
     sys_in  = "wt"    
-    out     = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = multi_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     
     @test out[1].G_system ≈ -916.8283889543869 rtol=2e-4
     @test out[2].G_system ≈ -912.5920719174167 rtol=2e-4
@@ -354,7 +354,7 @@ end
     Xoxides = ["SiO2", "Al2O3", "MgO", "FeO", "O", "H2O", "S"];
     X       = [20.044,0.6256,29.24,3.149,0.0,46.755,0.0]
     sys_in  = "mol"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
 end
 
 @testset "PT adaptive refinement" begin
@@ -367,19 +367,19 @@ end
     Xoxides     = ["SiO2","Al2O3","CaO","MgO","FeO","K2O","Na2O","TiO2","O","MnO","H2O"]
     X           = [70.999,12.805,0.771,3.978,6.342,2.7895,1.481,0.758,0.72933,0.075,30.0]
     sys_in      = "mol"    
-    out         = AMR_minimization(init_sub, ref_lvl, Prange, Trange, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out         = AMR_minimization(init_sub, ref_lvl, Prange, Trange, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     @test length(out) == 81
     @test sort(out[66].ph) == sort(["cd", "bi", "liq", "fsp", "sp", "ilm", "H2O"])
     Finalize_MAGEMin(data)
 end
 
 @testset "Trace-element partitioning model" begin
-    data    = Initialize_MAGEMin("mp", verbose=1, solver=0);
+    data    = Initialize_MAGEMin("mp", verbose=-1, solver=0);
     P,T     = 6.0, 699.0
     Xoxides = ["SiO2";  "TiO2";  "Al2O3";  "FeO";   "MnO";   "MgO";   "CaO";   "Na2O";  "K2O"; "H2O"; "O"];
     X       = [58.509,  1.022,   14.858, 4.371, 0.141, 4.561, 5.912, 3.296, 2.399, 10.0, 0.2];
     sys_in  = "wt"
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in, name_solvus=true)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in, name_solvus=true);
     Finalize_MAGEMin(data)
 
 
@@ -392,7 +392,7 @@ end
 
     KDs_database = create_custom_KDs_database(el, ph, KDs)
 
-    out_TE = TE_prediction(out, C0, KDs_database, dtb; ZrSat_model = "CB")
+    out_TE = TE_prediction(out, C0, KDs_database, dtb; ZrSat_model = "CB");
 
     @test out_TE.Cliq[1] ≈ 154.51891525771387 rtol=1e-3
     @test out_TE.Cliq[2] ≈ 3107.727391290317 rtol=1e-3
@@ -406,7 +406,7 @@ end
     Xoxides = ["SiO2","Al2O3","CaO","MgO","FeO","K2O","Na2O","TiO2","O","MnO","H2O"]
     X       = [70.999,12.805,0.771,3.978,6.342,2.7895,1.481,0.758,0.72933,0.075,30.0]
     sys_in  = "mol"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in,rm_list=rm_list)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in,rm_list=rm_list);
     @test sort(out.ph) == sort(["fsp", "g", "ilmm", "sp", "q", "sill", "H2O"])
     Finalize_MAGEMin(data)
 
@@ -416,7 +416,7 @@ end
     Xoxides = ["SiO2","Al2O3","CaO","MgO","FeO","K2O","Na2O","TiO2","O","MnO","H2O"]
     X       = [70.999,12.805,0.771,3.978,6.342,2.7895,1.481,0.758,0.72933,0.075,30.0]
     sys_in  = "mol"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in,rm_list=rm_list)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in,rm_list=rm_list);
     @test sort(out.ph) == sort(["fsp", "cd", "sa", "ilm", "sp", "q", "H2O"])
     Finalize_MAGEMin(data)
 end
@@ -435,7 +435,7 @@ end
     sys_in  = "wt"
     P_view  = @view P[1:2]
     T_view  = @view T[1:2]
-    out     = multi_point_minimization(P_view, T_view, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = multi_point_minimization(P_view, T_view, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
 
     # test with a view of the bulk rock
     index_shufle   = [2,1,3,4,5,6,7,8,9,10,11]
@@ -443,7 +443,7 @@ end
     X1_view        = @view X1[index_shufle]
 
     # just run it to be sure it is not erroring
-    out     = single_point_minimization(P[3], T[3], data, X=X1_view, Xoxides=Xoxides_shufle, sys_in=sys_in)
+    out     = single_point_minimization(P[3], T[3], data, X=X1_view, Xoxides=Xoxides_shufle, sys_in=sys_in);
     mol2wt(X1_view, Xoxides_shufle) # convert to mol
     wt2mol(X1_view, Xoxides_shufle) # convert to mol
 
@@ -527,7 +527,7 @@ end
     X           = [64.13, 0.91, 19.63, 6.85, 0.08, 2.41, 0.65, 1.38, 3.95, 40.0]
     Xoxides     = ["SiO2", "TiO2", "Al2O3", "FeO", "MnO", "MgO", "CaO", "Na2O", "K2O", "H2O"]
     sys_in      = "wt%"
-    out         =   single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out         =   single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     Finalize_MAGEMin(data)
 
     id_bi = findfirst(isequal("bi"), out.ph)
@@ -735,8 +735,8 @@ println("Override Ws")
     Xoxides = ["SiO2","Al2O3","CaO","MgO","FeO","K2O","Na2O","TiO2","O","MnO","H2O"]
     X       = [70.999,12.805,0.771,3.978,6.342,2.7895,1.481,0.758,0.72933,0.075,30.0]
     sys_in  = "mol"    
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in,W=new_Ws)
-    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in,W=new_Ws);
+    out     = single_point_minimization(P, T, data, X=X, Xoxides=Xoxides, sys_in=sys_in);
     @test norm(out.ph_frac) - 0.456 < 0.01
 end
 

--- a/tools/access_ds-data.jl
+++ b/tools/access_ds-data.jl
@@ -1,0 +1,49 @@
+using MAGEMin_C
+
+dtb                     = "mp"
+gv, z_b, DB, splx_data  = init_MAGEMin(dtb);
+
+# here the database is initialized with default test value and random PT conditions, this to access W's and G's
+gv                      = use_predefined_bulk_rock(gv, 0, dtb);
+gv, z_b, DB, splx_data  = pwm_init(8.0, 800.0, gv, z_b, DB, splx_data);
+
+# Here you need to provide the right tc-ds number for the database  you want to access
+arr_ptr                 = LibMAGEMin.get_arr_em_db_tc(gv.EM_dataset)   # Returns Ptr{EM_db}  # for tc-ds62
+
+# The following loads all structs into a Julia array
+arr                     = [unsafe_load(arr_ptr, i) for i in 1:gv.n_em_db] 
+
+# The following extracts the names as strings
+em_names                = [String(reinterpret(UInt8, collect(arr[i].Name))[1:nulpos-1])  for i in 1:gv.n_em_db]  
+
+#= val content:
+    enthalpy 		    = input_1[0];
+    entropy  		    = input_1[1];
+    volume   		    = input_1[2];
+
+    cpa      		    = input_2[0];
+    cpb      		    = input_2[1];
+    cpc      		    = input_2[2];
+    cpd      		    = input_2[3];
+
+    alpha0   		    = input_3[0];
+    kappa0   		    = input_3[1];
+    kappa0p  		    = input_3[2];
+    kappa0pp 		    = input_3[3];	
+=#
+
+id_fa                   = findfirst(isequal("fa"), em_names)  # find index of olivine
+
+val                     = unsafe_load(arr_ptr, id_fa)  # Get the struct at index 1
+HSV                     = val.input_1 # store H, S and V just for clarity
+
+fac                     = 0.99 # modify H, S and V, e.g. reduce by 1%
+setfield!(val, :input_1, tuple((HSV[i]*fac for i in 1:3)...))  # Modify the input_1 field with a new tuple
+
+# Now store the modified struct back to the array. Note that id_fa is used to store it back in the same position
+# Also note that saving the original values of the variables is important, as unsafe_store! overwrites the entire struct
+unsafe_store!(arr_ptr, val, id_fa)
+
+
+# Presently pwm_init includes compute_G0 function. This needs to be updated as the previous change have to occur right before.
+# then: pwm_run


### PR DESCRIPTION
- Corrected oversight introduced in v1.8.4 when using initial guess. This was leading to MAGEMin failing when using initial guess outside of PT diagram (PX, TX etc.). 
- Added option to access and modify standard state properties of the end-members through the Julia wrapper.